### PR TITLE
Fix flash reads on Linux due to CR/LF conversion

### DIFF
--- a/com.c
+++ b/com.c
@@ -101,6 +101,7 @@ bool COM_Open(char *port, uint32_t baudrate, bool have_parity, bool two_stopbits
       cfsetospeed(&SerialPortSettings, B115200);
       break;
   }
+  cfmakeraw(&SerialPortSettings);           /* Set raw mode (special processing disabled) */
   if (have_parity == true)
     SerialPortSettings.c_cflag |= PARENB;   /* Enables the Parity Enable bit(PARENB) */
   else
@@ -108,14 +109,8 @@ bool COM_Open(char *port, uint32_t baudrate, bool have_parity, bool two_stopbits
   if (two_stopbits == true)
     SerialPortSettings.c_cflag |= CSTOPB;   /* CSTOPB = 2 Stop bits */
   else
-	  SerialPortSettings.c_cflag &= ~CSTOPB;  /* CSTOPB = 2 Stop bits,here it is cleared so 1 Stop bit */
-  SerialPortSettings.c_cflag &= ~CSIZE;	    /* Clears the mask for setting the data size             */
-  SerialPortSettings.c_cflag |=  CS8;       /* Set the data bits = 8                                 */
-  //SerialPortSettings.c_cflag &= ~CRTSCTS;       /* No Hardware flow Control                         */
+    SerialPortSettings.c_cflag &= ~CSTOPB;  /* CSTOPB = 2 Stop bits,here it is cleared so 1 Stop bit */
   SerialPortSettings.c_cflag |= (CREAD | CLOCAL); /* Enable receiver,Ignore Modem Control lines       */
-  SerialPortSettings.c_iflag &= ~(IXON | IXOFF | IXANY);          /* Disable XON/XOFF flow control both i/p and o/p */
-  SerialPortSettings.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);  /* Non Cannonical mode      */
-  SerialPortSettings.c_oflag = 0;                // no remapping, no delays
   SerialPortSettings.c_cc[VMIN]  = 0;            // read doesn't block
   SerialPortSettings.c_cc[VTIME] = 5;            // 0.1 seconds read timeout
   tcsetattr(fd, TCSANOW, &SerialPortSettings);  /* Set the attributes to the termios structure*/

--- a/com.c
+++ b/com.c
@@ -34,6 +34,7 @@ static uint32_t COM_Baudrate = 115200;
 bool COM_Open(char *port, uint32_t baudrate, bool have_parity, bool two_stopbits)
 {
   printf("Opening %s at %u baud\n", port, baudrate);
+  COM_Baudrate = baudrate;
   #ifdef __MINGW32__
   char str[64];
   uint8_t multiplier;
@@ -66,7 +67,6 @@ bool COM_Open(char *port, uint32_t baudrate, bool have_parity, bool two_stopbits
   timeouts.WriteTotalTimeoutMultiplier = 1;
   timeouts.WriteTotalTimeoutConstant = 1;
   SetCommTimeouts(hSerial, &timeouts);
-  COM_Baudrate = baudrate;
   //COM_Bytes = 0;
   #endif
 


### PR DESCRIPTION
While attempting to verify writes to my device on a Raspberry Pi, I kept getting errors at certain byte locations (same bytes each time). A little investigation showed that the expected byte was 0x0D but 0x0A was read.

It looks like the c_iflag values weren't being set to turn off CR/LF conversion, so this change makes use of cfmakeraw to set up the termios for raw input/output, which fixes the 0x0D->0x0A conversion.